### PR TITLE
[connectionagent] Allow D-Bus activation only through systemd. JB#52572

### DIFF
--- a/config/com.jolla.Connectiond.service
+++ b/config/com.jolla.Connectiond.service
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=com.jolla.Connectiond
-ExecStart=/usr/bin/invoker -o --type=qt5 /usr/bin/connectionagent $CONNECTIONAGENT_TRACING
+Exec=/bin/false
 SystemdService=connectionagent.service
 Interface=/Connectiond


### PR DESCRIPTION
Starting D-Bus services should happen only via systemd. Using a dummy
Exec line in D-Bus configuration ensures that systemd can't be bypassed.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>