### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/connectionagent-qt5.spec
+++ b/rpm/connectionagent-qt5.spec
@@ -18,7 +18,7 @@ BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(qt5-boostable)
-BuildRequires:  systemd
+BuildRequires:  pkgconfig(systemd)
 Provides:   connectionagent > 0.10.1
 Obsoletes:   connectionagent <= 0.7.6
 


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.