### PR TITLE
Use connman enums. JB#61909

### DIFF
--- a/connd/qconnectionagent.cpp
+++ b/connd/qconnectionagent.cpp
@@ -65,9 +65,7 @@ QConnectionAgent::QConnectionAgent(QObject *parent) :
     connect(netman.data(), &NetworkManager::servicesListChanged, this, &QConnectionAgent::servicesListChanged);
     connect(netman.data(), &NetworkManager::stateChanged, this, &QConnectionAgent::networkStateChanged);
     connect(netman.data(), &NetworkManager::offlineModeChanged, this, &QConnectionAgent::offlineModeChanged);
-    connect(netman.data(), &NetworkManager::servicesChanged, this, [=]() {
-        updateServices();
-    });
+    connect(netman.data(), &NetworkManager::servicesChanged, this, &QConnectionAgent::updateServices);
     connect(netman.data(), &NetworkManager::technologiesChanged, this, &QConnectionAgent::techChanged);
 
     QFile connmanConf("/etc/connman/main.conf");

--- a/connd/qconnectionagent.h
+++ b/connd/qconnectionagent.h
@@ -115,7 +115,6 @@ private:
     ServiceList orderedServicesList;
     QStringList techPreferenceList;
     bool isEthernet;
-    bool connmanAvailable;
 
     NetworkTechnology *tetheringWifiTech;
     NetworkTechnology *tetheringBtTech;

--- a/connd/qconnectionagent.h
+++ b/connd/qconnectionagent.h
@@ -151,7 +151,7 @@ private slots:
 
     void serviceAutoconnectChanged(bool);
     void scanTimeout();
-    void techTetheringChanged(bool b);
+    void techTetheringChanged(bool on);
 
     void openConnectionDialog(const QString &type);
     void enableWifiTethering();

--- a/connd/qconnectionagent.h
+++ b/connd/qconnectionagent.h
@@ -23,6 +23,7 @@
 #include <QLoggingCategory>
 
 #include "networkmanager.h"
+#include "networkservice.h"
 
 class UserAgent;
 class NetworkService;
@@ -105,14 +106,12 @@ private:
 
     void setup();
     void updateServices();
-    bool isStateOnline(const QString &state);
     void removeAllTypes(const QString &type);
 
     bool shouldSuppressError(const QString &error, bool cellular) const;
 
     UserAgent *ua;
     QSharedPointer<NetworkManager> netman;
-    QString currentNetworkState;
     ServiceList orderedServicesList;
     QStringList techPreferenceList;
     bool isEthernet;
@@ -137,10 +136,10 @@ private:
 
 private slots:
     void serviceErrorChanged(const QString &error);
-    void serviceStateChanged(const QString &state);
-    void networkStateChanged(const QString &state);
+    void serviceStateChanged(NetworkService::ServiceState state);
+    void networkManagerStateChanged(NetworkManager::State state);
 
-    void connmanAvailabilityChanged(bool b);
+    void connmanAvailabilityChanged(bool available);
     void servicesError(const QString &);
     void technologyPowerChanged(bool);
     void techChanged();

--- a/connectionagentplugin/declarativeconnectionagent.cpp
+++ b/connectionagentplugin/declarativeconnectionagent.cpp
@@ -17,12 +17,6 @@
 #include "declarativeconnectionagent.h"
 #include "connectiond_interface.h"
 
-#include <connman-qt5/networkmanager.h>
-#include <connman-qt5/networktechnology.h>
-#include <connman-qt5/networkservice.h>
-
-#include <qobject.h>
-
 #define CONND_SERVICE "com.jolla.Connectiond"
 #define CONND_PATH "/Connectiond"
 

--- a/connectionagentplugin/declarativeconnectionagent.h
+++ b/connectionagentplugin/declarativeconnectionagent.h
@@ -17,8 +17,9 @@
 #ifndef DECLARATIVECONNECTIONAGENT_H
 #define DECLARATIVECONNECTIONAGENT_H
 
-#include "declarativeconnectionagent.h"
 #include "connectiond_interface.h"
+
+#include <QObject>
 
 /*
  *This class is for accessing connman's UserAgent from multiple sources.

--- a/test/auto/tst_connectionagent_plugin/tst_connectionagent_plugintest.cpp
+++ b/test/auto/tst_connectionagent_plugin/tst_connectionagent_plugintest.cpp
@@ -83,8 +83,8 @@ void Tst_connectionagent_pluginTest::testRequestConnection()
     for (int i = 0; i < wifiServices.count(); i++) {
         if (wifiServices[i]->autoConnect())
             wifiServices[i]->setAutoConnect(false);
-        if (wifiServices[i]->state() == "online"
-                || wifiServices[i]->state() == "ready") {
+        if (wifiServices[i]->serviceState() == NetworkService::OnlineState
+                || wifiServices[i]->serviceState() == NetworkService::ReadyState) {
             wifiServices[i]->requestDisconnect();
             //autoconnect disables the requestConnect signal
         }
@@ -135,7 +135,7 @@ void Tst_connectionagent_pluginTest::testUserInputRequested()
         }
         if (wifiServices[i]->autoConnect())
             wifiServices[i]->setAutoConnect(false);
-        if (wifiServices[i]->state() == "idle") {
+        if (wifiServices[i]->serviceState() == NetworkService::IdleState) {
             wifiServices[i]->requestConnect();
             break;
         }
@@ -183,7 +183,7 @@ void Tst_connectionagent_pluginTest::tst_tethering()
     
         QTest::qWait(5000);
     
-        QVERIFY(mobiledataService->state() == "online");
+        QVERIFY(mobiledataService->serviceState() == NetworkService::OnlineState);
     
         plugin->stopTethering("wifi");
         QTest::qWait(2500);
@@ -228,7 +228,7 @@ void Tst_connectionagent_pluginTest::tst_tethering()
 //    QCOMPARE(arguments.at(0).toBool(), false);
 
 //    NetworkService *cellServices = netman->getServices("cellular").at(0);
-//    QVERIFY(cellServices->state() == "idle");
+//    QVERIFY(cellServices->serviceState() == NetworkService::IdleState);
 }
 
 QTEST_MAIN(Tst_connectionagent_pluginTest)


### PR DESCRIPTION
From main commit:

```
Removed storing the service state to the config file. As transient
state it was strange there. Was added with commit 9eeeae
it actually read the value back, but these days this was only
writing.

The old code was also slightly mixing up network manager and network
service states on connmanAvailabilityChanged(), but then not actually
using the stored network service state anywhere. Removed that too.
``` 

Also various cleanups while at it.