### PR TITLE
[connectionagent] Remove bogus connman-qt5-declarative dependency. JB#63189

### DIFF
--- a/rpm/connectionagent-qt5.spec
+++ b/rpm/connectionagent-qt5.spec
@@ -6,7 +6,6 @@ Release:    0
 License:    LGPLv2
 URL:        https://github.com/sailfishos/connectionagent/
 Source0:    %{name}-%{version}.tar.bz2
-Requires:   connman-qt5-declarative
 Requires:   systemd
 Requires:   systemd-user-session-targets
 Requires:   connman >= 1.21


### PR DESCRIPTION
Doesn't make any sense, this is a d-bus service.